### PR TITLE
find understat and oddsapi discrepancies, add to translate function

### DIFF
--- a/data/processed/odds/odds_matchday_2024-12-21.csv
+++ b/data/processed/odds/odds_matchday_2024-12-21.csv
@@ -1,0 +1,6 @@
+match,1,x,2,ovr_und_point,over,under
+Aston Villa v. Manchester City,3.1,3.65,2.07,2.5,1.54,2.32
+Brentford v. Nottingham Forest,2.19,3.5,2.95,2.5,1.68,2.05
+West Ham United v. Brighton and Hove Albion,2.91,3.6,2.18,3.5,2.3,1.55
+Ipswich Town v. Newcastle United,4.4,3.85,1.69,2.5,1.58,2.23
+Crystal Palace v. Arsenal,5.1,3.95,1.59,2.5,1.76,1.95

--- a/notebooks/03_retrieve_odds.ipynb
+++ b/notebooks/03_retrieve_odds.ipynb
@@ -51,7 +51,7 @@
     "base_url = \"https://api.the-odds-api.com/v4/sports/soccer_epl/odds\"\n",
     "\n",
     "\"\"\"!!! ENTER MATCHDAY HERE !!!\"\"\"\n",
-    "matchday = \"2024-12-16\"\n",
+    "matchday = \"2024-12-21\"\n",
     "\n",
     "request_params = {\n",
     "    \"apiKey\": odds_api_key,\n",

--- a/notebooks/04_analysis_template.ipynb
+++ b/notebooks/04_analysis_template.ipynb
@@ -301,6 +301,7 @@
     "def translate(string):\n",
     "\n",
     "    translations = {\n",
+    "        \"Brighton\": \"Brighton and Hove Albion\",\n",
     "        \"Ipswich\": \"Ipswich Town\",\n",
     "        \"Leicester\": \"Leicester City\",\n",
     "        \"Tottenham\": \"Tottenham Hotspur\",\n",

--- a/notebooks/api_discrepancy/api_discrepancy_epl_2024-2025.ipynb
+++ b/notebooks/api_discrepancy/api_discrepancy_epl_2024-2025.ipynb
@@ -1,0 +1,137 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quick notebook to find all the discrepencies in naming between UnderStat and OddsApi for the English Premier League 2024-25 season"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Arsenal', 'Everton', 'Liverpool', 'Fulham', 'Wolverhampton Wanderers', 'Ipswich Town', 'Newcastle United', 'Leicester City', 'Nottingham Forest', 'Aston Villa', 'Manchester City', 'Manchester United', 'Chelsea', 'Brentford', 'Southampton', 'Tottenham Hotspur', 'Bournemouth', 'West Ham United']\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import json\n",
+    "oddsApi_clubs = []\n",
+    "csv1 = pd.read_csv('../../data/processed/odds/odds_matchday_2024-12-14.csv')\n",
+    "csv2 = pd.read_csv('../../data/processed/odds/odds_matchday_2024-12-15.csv')\n",
+    "csv3 = pd.read_csv('../../data/processed/odds/odds_matchday_2024-12-16.csv')\n",
+    "\n",
+    "def extend(input, to_list):\n",
+    "    for m in input:\n",
+    "        lst = m.split(' v. ')\n",
+    "        to_list.extend(lst)\n",
+    "\n",
+    "extend(csv1[\"match\"], oddsApi_clubs)\n",
+    "extend(csv2[\"match\"], oddsApi_clubs)\n",
+    "extend(csv3[\"match\"], oddsApi_clubs)\n",
+    "\n",
+    "print(oddsApi_clubs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Arsenal', 'Aston Villa', 'Bournemouth', 'Brentford', 'Brighton and Hove Albion', 'Chelsea', 'Crystal Palace', 'Everton', 'Fulham', 'Ipswich Town', 'Leicester City', 'Liverpool', 'Manchester City', 'Manchester United', 'Newcastle United', 'Nottingham Forest', 'Southampton', 'Tottenham Hotspur', 'West Ham United', 'Wolverhampton Wanderers']\n"
+     ]
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "I discovered I was missing Brighton and Crystal Palace in my csv because of the time of day that I ran it (OddsApi free tier doesn't retrieve past odds, only upcoming).\n",
+    "\n",
+    "The following is logic to correct\n",
+    "\"\"\"\n",
+    "# read a csv for a future matchday to retrieve the missing club names\n",
+    "csv4 = pd.read_csv('../../data/processed/odds/odds_matchday_2024-12-21.csv')\n",
+    "\n",
+    "extend(csv4[\"match\"], oddsApi_clubs)\n",
+    "\n",
+    "oddsApi_clubs = list(set(oddsApi_clubs)) # remove duplicates\n",
+    "oddsApi_clubs.sort()\n",
+    "print(oddsApi_clubs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"Brighton\": \"Brighton and Hove Albion\",\n",
+      "  \"Ipswich\": \"Ipswich Town\",\n",
+      "  \"Leicester\": \"Leicester City\",\n",
+      "  \"Tottenham\": \"Tottenham Hotspur\",\n",
+      "  \"West Ham\": \"West Ham United\"\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "underStat_clubs = []\n",
+    "\n",
+    "csv5 = pd.read_csv('../../data/processed/away_table.csv')\n",
+    "extend(csv5[\"Team\"], underStat_clubs)\n",
+    "underStat_clubs.sort()\n",
+    "\n",
+    "translations = {}\n",
+    "for a, b in zip(underStat_clubs, oddsApi_clubs):\n",
+    "    if a != b:\n",
+    "        translations[a] = b\n",
+    "\n",
+    "print(json.dumps(translations, indent=2))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Summary:\n",
+    "\n",
+    "The translations dictionary is what is need for the translate function found in `notebooks/04_analysis_template.ipynb`. This logic can be used for any league to resolve compatability issues between Understat and the OddsApi"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### What this PR does:

This PR adds a notebook where I find the discrepancies between the UnderStat and OddsApi naming and translate them where needed in the analysis notebook.

This can be reused for any league where this issue arises